### PR TITLE
Fix Single CR causing issues with lines not being recognized as 2 lines

### DIFF
--- a/Test-DeviceRegConnectivity.ps1
+++ b/Test-DeviceRegConnectivity.ps1
@@ -242,7 +242,8 @@ Function Test-DevRegConnectivity{
 }
 
 Function PSasAdmin{
-    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())    $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+    $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
 $global:Bypass=""


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* The line ending at https://github.com/Azure-Samples/TestDeviceRegConnectivity/blob/2b8d0592cfcbd13a32546212c939924b70c57c0e/Test-DeviceRegConnectivity.ps1#L245 has only a Carriage Return, not CR-LF or LF, causing two lines to be recognized as a single line, and breaking syntax. 

* This ultimately meant that the script refused to acknowledge that anyone was an Administrator, and usually failed to run.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Fixing a line-ending issue, causing the script to break in most environments without manually editing/fixing it
```

## How to Test
*  Get the code
* I recommend you download the code manually through a browser, in case Git is trying to handle line-ending switches/updating by default - here is a link to a file version that has the issue https://raw.githubusercontent.com/Azure-Samples/TestDeviceRegConnectivity/2b8d0592cfcbd13a32546212c939924b70c57c0e/Test-DeviceRegConnectivity.ps1

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```ps
#run the script from an Admin session, I used the code below, running as System
cd $env:temp
$hostedCodeURL = 'https://raw.githubusercontent.com/Azure-Samples/TestDeviceRegConnectivity/2b8d0592cfcbd13a32546212c939924b70c57c0e/Test-DeviceRegConnectivity.ps1'
Invoke-WebRequest $hostedCodeURL -OutFile Test-DeviceRegConnectivity.ps1
Unblock-File .\Test-DeviceRegConnectivity.ps1
.\Test-DeviceRegConnectivity.ps1 
```

## What to Check
Verify that the following are valid
* With the code downloaded and not modified in the screenshot below, you can see the default script is failing on Lack of Administrator Rights
* But when I manually extracted and split the relevant lines to 2 separate lines instead of one "combined" line, it recognized me as Administrator correctly. 
![image](https://github.com/Azure-Samples/TestDeviceRegConnectivity/assets/3719116/0a8d555c-a61c-490e-9dc9-f92ba1c97451)



## Other Information
This also may fix issues #4 , #7 , if I am reading their error messages right 

There are also several places that only have a LF, but no CR, which doesn't match the rest of the file, which has the whole CR-LF. Mainly, this seems to be the comments, and PowerShell often creates LF only content even when the file is CRLF endings by default, so this doesn't really affect functionality, but might be good to make it uniform across the whole file. 

https://github.com/Azure-Samples/TestDeviceRegConnectivity/blob/2b8d0592cfcbd13a32546212c939924b70c57c0e/Test-DeviceRegConnectivity.ps1#L35
https://github.com/Azure-Samples/TestDeviceRegConnectivity/blob/2b8d0592cfcbd13a32546212c939924b70c57c0e/Test-DeviceRegConnectivity.ps1#L67
https://github.com/Azure-Samples/TestDeviceRegConnectivity/blob/2b8d0592cfcbd13a32546212c939924b70c57c0e/Test-DeviceRegConnectivity.ps1#L102
https://github.com/Azure-Samples/TestDeviceRegConnectivity/blob/2b8d0592cfcbd13a32546212c939924b70c57c0e/Test-DeviceRegConnectivity.ps1#L210
https://github.com/Azure-Samples/TestDeviceRegConnectivity/blob/2b8d0592cfcbd13a32546212c939924b70c57c0e/Test-DeviceRegConnectivity.ps1#L284
https://github.com/Azure-Samples/TestDeviceRegConnectivity/blob/2b8d0592cfcbd13a32546212c939924b70c57c0e/Test-DeviceRegConnectivity.ps1#L301-L514
